### PR TITLE
Adding Windows commandline capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"author": "Flow Works",
 	"type": "module",
 	"scripts": {
-		"start": "NODE_ENV=production node src/index.js",
+		"start": "if (process.platform==='win32') {set NODE_ENV=production node src/index.js} else {NODE_ENV=production node src/index.js}",
 		"dev": "nodemon src/index.js",
 		"lint": "eslint --ext .js --ignore-path .gitignore .",
 		"commit": "cz"


### PR DESCRIPTION
"yarn start" returns an error in cmd, so I changed it to check if the host os was Windows, and ran the command with set if the os was windows.